### PR TITLE
feat: add product catalog and detail page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,13 +1,125 @@
+import { useEffect, useState } from 'react';
 import Header from './components/Header.jsx';
 import Hero from './components/Hero.jsx';
 import Footer from './components/Footer.jsx';
+import ProductGrid from './components/ProductGrid.jsx';
+import ProductDetail from './components/ProductDetail.jsx';
+import products from './data/products.js';
+
+const parseProductFromHash = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const hash = window.location.hash ?? '';
+  const match = hash.match(/^#\/products\/([a-z0-9-]+)$/i);
+  return match ? match[1] : null;
+};
 
 const App = () => {
+  const [selectedProductId, setSelectedProductId] = useState(() => parseProductFromHash());
+
+  useEffect(() => {
+    const syncFromLocation = () => {
+      setSelectedProductId(parseProductFromHash());
+    };
+
+    window.addEventListener('popstate', syncFromLocation);
+    window.addEventListener('hashchange', syncFromLocation);
+
+    return () => {
+      window.removeEventListener('popstate', syncFromLocation);
+      window.removeEventListener('hashchange', syncFromLocation);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedProductId || typeof window === 'undefined') {
+      return;
+    }
+
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [selectedProductId]);
+
+  const scrollToProducts = () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const scroll = () => {
+      const section = document.getElementById('products');
+      if (section) {
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    };
+
+    window.requestAnimationFrame(scroll);
+  };
+
+  const updateHash = (hash, state = {}) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (window.location.hash === hash) {
+      window.history.replaceState(state, '', hash);
+    } else {
+      window.history.pushState(state, '', hash);
+    }
+  };
+
+  const handleProductSelect = (productId) => {
+    setSelectedProductId(productId);
+    updateHash(`#/products/${productId}`, { productId });
+  };
+
+  const navigateHome = (options = {}) => {
+    setSelectedProductId(null);
+    updateHash('#/', {});
+
+    if (options.scrollTo === 'products') {
+      setTimeout(() => {
+        scrollToProducts();
+      }, 80);
+    } else if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  const handleBackToProducts = () => {
+    navigateHome({ scrollTo: 'products' });
+  };
+
+  const selectedProduct = selectedProductId
+    ? products.find((product) => product.id === selectedProductId)
+    : null;
+
   return (
     <div className="app">
-      <Header />
+      <Header onNavigateHome={() => navigateHome()} onShopClick={handleBackToProducts} />
       <main>
-        <Hero />
+        {selectedProductId && !selectedProduct && (
+          <div className="product-detail not-found">
+            <div className="product-detail__content">
+              <h1>Không tìm thấy sản phẩm</h1>
+              <p>Sản phẩm bạn tìm kiếm hiện không tồn tại hoặc đã được cập nhật.</p>
+              <button type="button" className="primary" onClick={handleBackToProducts}>
+                Quay lại danh mục
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!selectedProductId && (
+          <>
+            <Hero onShopClick={() => navigateHome({ scrollTo: 'products' })} />
+            <ProductGrid products={products} onProductSelect={handleProductSelect} />
+          </>
+        )}
+
+        {selectedProduct && (
+          <ProductDetail product={selectedProduct} onBack={handleBackToProducts} />
+        )}
       </main>
       <Footer />
     </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,13 +1,25 @@
 const navigationLinks = [
-  'Shop',
-  'New Arrivals',
-  'Nam',
-  'Nữ',
-  'About Us',
-  'Best Seller'
+  { label: 'Shop', type: 'button' },
+  { label: 'New Arrivals', href: '#' },
+  { label: 'Nam', href: '#' },
+  { label: 'Nữ', href: '#' },
+  { label: 'About Us', href: '#' },
+  { label: 'Best Seller', href: '#' }
 ];
 
-const Header = () => {
+const Header = ({ onNavigateHome, onShopClick }) => {
+  const handleLogoClick = () => {
+    if (typeof onNavigateHome === 'function') {
+      onNavigateHome();
+    }
+  };
+
+  const handleShopClick = () => {
+    if (typeof onShopClick === 'function') {
+      onShopClick();
+    }
+  };
+
   return (
     <header className="header">
       <div className="top-bar">
@@ -16,16 +28,27 @@ const Header = () => {
       </div>
       <div className="nav-bar">
         <div className="logo-area">
-          <div className="logo" aria-label="Clothing Store Logo">
+          <button
+            type="button"
+            className="logo"
+            aria-label="Trang chủ Clothing Store"
+            onClick={handleLogoClick}
+          >
             <span className="logo-icon">CS</span>
             <span className="logo-text">logo</span>
-          </div>
+          </button>
         </div>
         <nav className="navigation">
           <ul>
             {navigationLinks.map((link) => (
-              <li key={link}>
-                <a href="#">{link}</a>
+              <li key={link.label}>
+                {link.type === 'button' ? (
+                  <button type="button" className="link-button" onClick={handleShopClick}>
+                    {link.label}
+                  </button>
+                ) : (
+                  <a href={link.href}>{link.label}</a>
+                )}
               </li>
             ))}
           </ul>

--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -1,4 +1,10 @@
-const Hero = () => {
+const Hero = ({ onShopClick }) => {
+  const handleShopNow = () => {
+    if (typeof onShopClick === 'function') {
+      onShopClick();
+    }
+  };
+
   return (
     <section className="hero">
       <div className="hero-content">
@@ -8,8 +14,12 @@ const Hero = () => {
           ICS mang đến phong cách trẻ trung, năng động với cảm hứng từ văn hóa đường phố.
         </p>
         <div className="hero-actions">
-          <button className="primary">MUA NGAY</button>
-          <button className="secondary">XEM LOOKBOOK</button>
+          <button className="primary" type="button" onClick={handleShopNow}>
+            MUA NGAY
+          </button>
+          <button className="secondary" type="button">
+            XEM LOOKBOOK
+          </button>
         </div>
       </div>
     </section>

--- a/frontend/src/components/ProductDetail.jsx
+++ b/frontend/src/components/ProductDetail.jsx
@@ -1,0 +1,80 @@
+const ProductDetail = ({ product, onBack }) => {
+  const handleBack = () => {
+    if (typeof onBack === 'function') {
+      onBack();
+    }
+  };
+
+  return (
+    <section className="product-detail">
+      <div className="product-detail__container">
+        <div className="product-detail__breadcrumb">
+          <button type="button" onClick={handleBack}>
+            ← Quay lại danh mục
+          </button>
+        </div>
+        <div className="product-detail__layout">
+          <div className="product-detail__image">
+            <img src={product.image} alt={product.name} />
+          </div>
+          <div className="product-detail__info">
+            <span className="product-detail__category">{product.category}</span>
+            <h1 className="product-detail__title">{product.name}</h1>
+            <p className="product-detail__price">{product.price}</p>
+            <p className="product-detail__description">{product.longDescription}</p>
+
+            <div className="product-detail__meta">
+              <div>
+                <h3>Kích cỡ</h3>
+                <ul className="pill-list">
+                  {product.sizes.map((size) => (
+                    <li key={size}>{size}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3>Màu sắc</h3>
+                <ul className="pill-list">
+                  {product.colors.map((color) => (
+                    <li key={color}>{color}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            <div className="product-detail__extra">
+              <div>
+                <h3>Chất liệu</h3>
+                <p>{product.materials}</p>
+              </div>
+              <div>
+                <h3>Bảo quản</h3>
+                <p>{product.care}</p>
+              </div>
+            </div>
+
+            <div className="product-detail__features">
+              <h3>Điểm nổi bật</h3>
+              <ul>
+                {product.features.map((feature) => (
+                  <li key={feature}>{feature}</li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="product-detail__actions">
+              <button type="button" className="primary">
+                Thêm vào giỏ hàng
+              </button>
+              <button type="button" className="secondary" onClick={handleBack}>
+                Tiếp tục xem sản phẩm
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ProductDetail;

--- a/frontend/src/components/ProductGrid.jsx
+++ b/frontend/src/components/ProductGrid.jsx
@@ -1,0 +1,52 @@
+const ProductGrid = ({ products, onProductSelect }) => {
+  const handleSelect = (productId) => {
+    if (typeof onProductSelect === 'function') {
+      onProductSelect(productId);
+    }
+  };
+
+  const handleKeyDown = (event, productId) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleSelect(productId);
+    }
+  };
+
+  return (
+    <section className="product-section" id="products">
+      <div className="section-header">
+        <p className="section-subtitle">Sản phẩm mới</p>
+        <h2 className="section-title">Danh mục nổi bật</h2>
+        <p className="section-description">
+          Khám phá hơn 20 thiết kế streetwear được chọn lọc cho mùa này, từ áo khoác utility đến
+          phụ kiện đa năng.
+        </p>
+      </div>
+      <div className="product-grid">
+        {products.map((product) => (
+          <article
+            key={product.id}
+            className="product-card"
+            onClick={() => handleSelect(product.id)}
+            onKeyDown={(event) => handleKeyDown(event, product.id)}
+            tabIndex={0}
+            role="button"
+            aria-label={`Xem chi tiết ${product.name}`}
+          >
+            <div className="product-card__image">
+              <img src={product.image} alt={product.name} loading="lazy" />
+            </div>
+            <div className="product-card__info">
+              <span className="product-card__category">{product.category}</span>
+              <h3 className="product-card__name">{product.name}</h3>
+              <p className="product-card__description">{product.description}</p>
+              <span className="product-card__price">{product.price}</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProductGrid;

--- a/frontend/src/data/products.js
+++ b/frontend/src/data/products.js
@@ -1,0 +1,404 @@
+const products = [
+  {
+    id: 'urban-flare-hoodie',
+    name: 'Urban Flare Hoodie',
+    category: 'Áo khoác',
+    price: '690.000đ',
+    description: 'Áo hoodie form rộng chất nỉ dày, phối màu khói thời thượng.',
+    longDescription:
+      'Urban Flare Hoodie sử dụng chất nỉ dày dặn kết hợp xử lý chống xù giúp giữ phom bền đẹp. Thân áo phối hai tông màu khói - trắng tạo hiệu ứng chuyển sắc hiện đại, phù hợp cho cả nam và nữ.',
+    image:
+      'https://images.unsplash.com/photo-1542293787938-4d2226c63dc3?auto=format&fit=crop&w=1200&q=80',
+    materials: '80% Cotton, 20% Polyester',
+    care: 'Giặt máy chế độ nhẹ, lộn trái khi giặt, phơi nơi thoáng mát.',
+    colors: ['Khói Xám', 'Đen'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    features: [
+      'Form oversized dễ phối đồ',
+      'Bo tay co giãn đàn hồi tốt',
+      'Logo thêu 3D trước ngực'
+    ]
+  },
+  {
+    id: 'skyline-cargo-jacket',
+    name: 'Skyline Cargo Jacket',
+    category: 'Áo khoác',
+    price: '890.000đ',
+    description: 'Áo khoác cargo đa túi chống nước nhẹ với khóa kéo kim loại.',
+    longDescription:
+      'Skyline Cargo Jacket được thiết kế từ chất liệu nylon dệt dày, phủ lớp chống nước mỏng cho khả năng cản gió tốt. Các chi tiết dây rút và khóa kéo kim loại giúp tăng tính tiện dụng khi di chuyển.',
+    image:
+      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1200&q=80',
+    materials: '100% Nylon phủ DWR',
+    care: 'Lau sạch bề mặt bằng khăn ẩm, hạn chế giặt máy.',
+    colors: ['Olive', 'Đen'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      '4 túi hộp tiện dụng',
+      'Dây rút điều chỉnh ở lai áo',
+      'Khóa kéo YKK bền bỉ'
+    ]
+  },
+  {
+    id: 'nebula-oversized-tee',
+    name: 'Nebula Oversized Tee',
+    category: 'Áo thun',
+    price: '390.000đ',
+    description: 'Áo thun oversize in họa tiết nebula độc đáo.',
+    longDescription:
+      'Nebula Oversized Tee sử dụng chất cotton 230gsm mềm mịn, in kỹ thuật DTG giúp màu sắc sống động và bền màu. Phom rộng thoải mái cùng họa tiết lấy cảm hứng từ vũ trụ tạo điểm nhấn nổi bật.',
+    image:
+      'https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=1200&q=80',
+    materials: '100% Cotton 230gsm',
+    care: 'Giặt máy với nước lạnh, không dùng chất tẩy mạnh.',
+    colors: ['Tím Nebula', 'Trắng'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    features: [
+      'Chất liệu cotton dày dặn',
+      'In DTG sắc nét',
+      'Đường may tỉ mỉ, ít nhăn'
+    ]
+  },
+  {
+    id: 'midnight-layered-shirt',
+    name: 'Midnight Layered Shirt',
+    category: 'Áo sơ mi',
+    price: '520.000đ',
+    description: 'Áo sơ mi layering với cổ tàu phối nút bọc lạ mắt.',
+    longDescription:
+      'Midnight Layered Shirt kết hợp thiết kế cổ tàu tối giản với lớp lót mỏng tạo hiệu ứng layering tinh tế. Chất vải rayon thoáng mát, phù hợp mặc đơn lẻ hoặc kết hợp cùng áo khoác nhẹ.',
+    image:
+      'https://images.unsplash.com/photo-1521572163474-dbf02766c3b3?auto=format&fit=crop&w=1200&q=80',
+    materials: '65% Rayon, 35% Polyester',
+    care: 'Ủi nhẹ ở nhiệt độ thấp, hạn chế vắt mạnh.',
+    colors: ['Đen', 'Xanh Đậm'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      'Thiết kế cổ tàu gọn gàng',
+      'Lớp lót mỏng thoáng khí',
+      'Nút bọc cùng tông màu'
+    ]
+  },
+  {
+    id: 'alloy-tech-jogger',
+    name: 'Alloy Tech Jogger',
+    category: 'Quần dài',
+    price: '610.000đ',
+    description: 'Jogger chất liệu co giãn 4 chiều với dây khóa điều chỉnh.',
+    longDescription:
+      'Alloy Tech Jogger sử dụng chất vải tổng hợp co giãn đa chiều, kết hợp khóa dây kéo ở ống quần giúp tùy chỉnh phom dáng. Thích hợp cho các hoạt động đường phố hoặc tập luyện nhẹ.',
+    image:
+      'https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=1200&q=80',
+    materials: '90% Polyester, 10% Spandex',
+    care: 'Giặt máy nước lạnh, không sấy nhiệt cao.',
+    colors: ['Xám Bạc', 'Đen'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    features: [
+      'Co giãn 4 chiều',
+      'Túi khóa kéo an toàn',
+      'Đai lưng co giãn kèm dây rút'
+    ]
+  },
+  {
+    id: 'vertex-denim-jacket',
+    name: 'Vertex Denim Jacket',
+    category: 'Áo khoác',
+    price: '920.000đ',
+    description: 'Áo denim wash loang với chi tiết cắt laser hiện đại.',
+    longDescription:
+      'Vertex Denim Jacket được xử lý wash loang kết hợp cắt laser tạo texture độc đáo. Form unisex dễ phối, lớp vải denim 12oz giữ nhiệt vừa đủ cho thời tiết se lạnh.',
+    image:
+      'https://images.unsplash.com/photo-1490111718993-d98654ce6cf7?auto=format&fit=crop&w=1200&q=80',
+    materials: 'Denim 12oz 100% Cotton',
+    care: 'Giặt tay với nước lạnh, không ngâm lâu.',
+    colors: ['Xanh Indigo', 'Đen Faded'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      'Kỹ thuật wash loang thủ công',
+      'Đinh tán kim loại cao cấp',
+      'Logo da ở thân sau'
+    ]
+  },
+  {
+    id: 'horizon-windbreaker',
+    name: 'Horizon Windbreaker',
+    category: 'Áo khoác nhẹ',
+    price: '780.000đ',
+    description: 'Áo gió hai lớp chống tia UV với khóa kéo ẩn.',
+    longDescription:
+      'Horizon Windbreaker có lớp vải ngoài chống tia UV UPF30+, lớp trong mesh thoáng khí. Thiết kế khóa kéo ẩn và túi hông có khóa giúp bảo vệ đồ dùng khi di chuyển.',
+    image:
+      'https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=1200&q=80',
+    materials: 'Polyester tái chế 100%',
+    care: 'Giặt máy nhẹ, không sử dụng chất tẩy.',
+    colors: ['Cam Cháy', 'Xanh Bạc Hà'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    features: [
+      'Chống tia UV UPF30+',
+      'Khóa kéo ẩn liền mạch',
+      'Đường viền phản quang'
+    ]
+  },
+  {
+    id: 'ember-knit-sweater',
+    name: 'Ember Knit Sweater',
+    category: 'Áo len',
+    price: '640.000đ',
+    description: 'Áo len dệt kim họa tiết gân nổi, chất liệu mềm nhẹ.',
+    longDescription:
+      'Ember Knit Sweater sử dụng sợi acrylic pha len merino cho cảm giác mềm mại, ít xù lông. Họa tiết gân nổi chạy dọc thân áo tạo hiệu ứng thị giác thanh lịch.',
+    image:
+      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80',
+    materials: '55% Acrylic, 30% Merino, 15% Nylon',
+    care: 'Giặt tay nước lạnh, phơi ngang tránh dão.',
+    colors: ['Đỏ Gạch', 'Be'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      'Sợi len merino mềm mịn',
+      'Thiết kế gân nổi tạo điểm nhấn',
+      'Cổ bo tròn ôm vừa vặn'
+    ]
+  },
+  {
+    id: 'driftwood-chino-pants',
+    name: 'Driftwood Chino Pants',
+    category: 'Quần dài',
+    price: '540.000đ',
+    description: 'Quần chino ống đứng với chi tiết gấu xếp ly tinh tế.',
+    longDescription:
+      'Driftwood Chino Pants sử dụng cotton twill dày dặn kết hợp elastane giúp giữ phom, tạo độ ôm nhẹ ở hông và buông dần xuống ống quần. Phù hợp phối cùng sơ mi hoặc áo thun.',
+    image:
+      'https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=1200&q=80',
+    materials: '97% Cotton, 3% Elastane',
+    care: 'Giặt máy chế độ nhẹ, ủi nhiệt độ trung bình.',
+    colors: ['Nâu Nhạt', 'Xanh Rêu'],
+    sizes: ['28', '30', '32', '34'],
+    features: [
+      'Ống đứng dễ mặc',
+      'Lưng quần khóa kéo kim loại',
+      'Chất vải twill bền màu'
+    ]
+  },
+  {
+    id: 'mirage-sport-hoodie',
+    name: 'Mirage Sport Hoodie',
+    category: 'Áo khoác',
+    price: '720.000đ',
+    description: 'Hoodie thể thao phối lưới thoáng khí, mũ trùm sâu.',
+    longDescription:
+      'Mirage Sport Hoodie kết hợp chất liệu spandex co giãn với mảng lưới mesh ở hai bên sườn tạo sự thông thoáng. Mũ trùm sâu và dây rút phản quang phù hợp cho hoạt động ngoài trời.',
+    image:
+      'https://images.unsplash.com/photo-1503341455253-b2e723bb3dbb?auto=format&fit=crop&w=1200&q=80',
+    materials: '85% Polyester, 15% Spandex',
+    care: 'Giặt tay hoặc máy ở chế độ nhẹ, không sấy nhiệt cao.',
+    colors: ['Xanh Navy', 'Đen'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    features: [
+      'Mũ trùm sâu chống gió',
+      'Mảng lưới mesh thoáng khí',
+      'Khóa kéo dài tới ngực'
+    ]
+  },
+  {
+    id: 'pulse-reflective-vest',
+    name: 'Pulse Reflective Vest',
+    category: 'Áo gile',
+    price: '480.000đ',
+    description: 'Áo gile phản quang kèm túi zipper trước ngực.',
+    longDescription:
+      'Pulse Reflective Vest là lựa chọn hoàn hảo cho những buổi đạp xe hoặc chạy bộ ban đêm. Lớp vải phản quang phủ toàn bộ mặt ngoài giúp bạn nổi bật và an toàn hơn trên đường phố.',
+    image:
+      'https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=1200&q=80',
+    materials: '100% Polyester phản quang',
+    care: 'Lau sạch bằng khăn ẩm, không ủi.',
+    colors: ['Bạc'],
+    sizes: ['Free Size'],
+    features: [
+      'Phản quang toàn diện',
+      'Túi zipper trước ngực',
+      'Cài khóa bấm dễ dàng'
+    ]
+  },
+  {
+    id: 'solstice-linen-shirt',
+    name: 'Solstice Linen Shirt',
+    category: 'Áo sơ mi',
+    price: '560.000đ',
+    description: 'Áo sơ mi linen thoáng mát, cổ mở chữ V mềm mại.',
+    longDescription:
+      'Solstice Linen Shirt sử dụng 100% sợi linen cao cấp, có khả năng thấm hút mồ hôi vượt trội. Thiết kế cổ chữ V mềm mại cùng tay áo lửng tạo cảm giác thoải mái cho mùa hè.',
+    image:
+      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80',
+    materials: '100% Linen',
+    care: 'Giặt tay, phơi mát, ủi khi áo còn ẩm.',
+    colors: ['Trắng Kem', 'Xanh Phấn'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      'Chất linen thoáng mát',
+      'Cổ chữ V nữ tính',
+      'Cúc gỗ tự nhiên'
+    ]
+  },
+  {
+    id: 'emberline-pleated-skirt',
+    name: 'Emberline Pleated Skirt',
+    category: 'Chân váy',
+    price: '520.000đ',
+    description: 'Chân váy xếp pli midi với lưng thun bản lớn.',
+    longDescription:
+      'Emberline Pleated Skirt có độ xòe nhẹ nhàng nhờ các đường pli đều nhau. Lưng thun bản lớn ôm gọn vòng eo nhưng vẫn tạo cảm giác thoải mái khi vận động.',
+    image:
+      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1200&q=80',
+    materials: '98% Polyester, 2% Spandex',
+    care: 'Giặt tay, phơi treo, không ủi nhiệt cao.',
+    colors: ['Nâu Gỗ', 'Đen'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      'Nếp pli giữ phom lâu',
+      'Lưng thun đàn hồi tốt',
+      'Độ dài midi tinh tế'
+    ]
+  },
+  {
+    id: 'apex-track-pants',
+    name: 'Apex Track Pants',
+    category: 'Quần thể thao',
+    price: '510.000đ',
+    description: 'Quần track pants phối sọc phản quang, chất liệu nhẹ.',
+    longDescription:
+      'Apex Track Pants làm từ vải dệt siêu nhẹ, có khả năng thoát ẩm nhanh. Sọc phản quang chạy dọc ống quần tạo điểm nhấn thể thao cá tính.',
+    image:
+      'https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=1200&q=80',
+    materials: '88% Polyester, 12% Spandex',
+    care: 'Giặt máy nhẹ, phơi mát.',
+    colors: ['Đen', 'Xanh Than'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    features: [
+      'Thoát ẩm nhanh',
+      'Sọc phản quang nổi bật',
+      'Ống bo gọn gàng'
+    ]
+  },
+  {
+    id: 'aurora-quilted-jacket',
+    name: 'Aurora Quilted Jacket',
+    category: 'Áo phao nhẹ',
+    price: '1.050.000đ',
+    description: 'Áo phao chần bông siêu nhẹ, phối màu chuyển sắc Aurora.',
+    longDescription:
+      'Aurora Quilted Jacket sử dụng sợi polyester tái chế với cấu trúc chần bông ô nhỏ giúp giữ nhiệt tốt mà vẫn nhẹ nhàng. Lớp phủ màu chuyển sắc tạo hiệu ứng aurora bắt mắt.',
+    image:
+      'https://images.unsplash.com/photo-1495107334309-fcf20504a5ab?auto=format&fit=crop&w=1200&q=80',
+    materials: 'Vỏ 100% Polyester tái chế, ruột bông microfiber',
+    care: 'Giặt khô hoặc giặt máy chế độ chuyên dụng cho áo phao.',
+    colors: ['Aurora Gradient'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      'Giữ nhiệt tốt, trọng lượng nhẹ',
+      'Hiệu ứng màu chuyển sắc độc đáo',
+      'Túi trong chống ẩm'
+    ]
+  },
+  {
+    id: 'vivid-gradient-hoodie',
+    name: 'Vivid Gradient Hoodie',
+    category: 'Áo hoodie',
+    price: '760.000đ',
+    description: 'Hoodie nhuộm chuyển màu Vivid, vải nỉ chải bông.',
+    longDescription:
+      'Vivid Gradient Hoodie sử dụng kỹ thuật nhuộm tie-dye kiểm soát tạo dải màu chuyển mượt. Lớp nỉ chải bông bên trong giữ ấm, đồng thời thoáng khí giúp mặc cả ngày.',
+    image:
+      'https://images.unsplash.com/photo-1556906781-9a412961c28c?auto=format&fit=crop&w=1200&q=80',
+    materials: '70% Cotton, 30% Polyester',
+    care: 'Giặt riêng sản phẩm màu đậm, tránh phơi trực tiếp dưới nắng gắt.',
+    colors: ['Gradient Cam-Tím'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    features: [
+      'Hiệu ứng gradient độc đáo',
+      'Nỉ chải bông giữ ấm',
+      'Mũ trùm rộng rãi'
+    ]
+  },
+  {
+    id: 'onyx-minimal-cap',
+    name: 'Onyx Minimal Cap',
+    category: 'Phụ kiện',
+    price: '260.000đ',
+    description: 'Nón lưỡi trai tối giản, khóa kéo kim loại điều chỉnh.',
+    longDescription:
+      'Onyx Minimal Cap có phom dáng cổ điển với chất vải canvas chống nhăn. Logo thêu tông xuyệt tông và khoá kim loại phía sau giúp điều chỉnh kích thước dễ dàng.',
+    image:
+      'https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=1200&q=80',
+    materials: 'Canvas chống nhăn',
+    care: 'Vệ sinh bằng bàn chải mềm và khăn ẩm.',
+    colors: ['Đen Onyx', 'Xám Tro'],
+    sizes: ['Free Size'],
+    features: [
+      'Chất liệu canvas bền',
+      'Khóa kim loại chắc chắn',
+      'Logo thêu tối giản'
+    ]
+  },
+  {
+    id: 'cascade-utility-bag',
+    name: 'Cascade Utility Bag',
+    category: 'Túi đeo',
+    price: '450.000đ',
+    description: 'Túi đeo chéo đa ngăn, dây đai bản lớn êm vai.',
+    longDescription:
+      'Cascade Utility Bag gồm 3 ngăn chính kèm túi phụ mặt trước giúp sắp xếp đồ dùng gọn gàng. Dây đai bản lớn lót mút êm vai, phù hợp mang theo khi đi làm hoặc dạo phố.',
+    image:
+      'https://images.unsplash.com/photo-1489987707025-afc232f7ea0f?auto=format&fit=crop&w=1200&q=80',
+    materials: 'Vải Cordura chống mài mòn',
+    care: 'Lau bằng khăn ẩm, hạn chế giặt máy.',
+    colors: ['Đen', 'Xanh Rêu'],
+    sizes: ['Dung tích 4L'],
+    features: [
+      'Chất liệu Cordura bền bỉ',
+      'Nhiều ngăn tiện dụng',
+      'Khóa kéo chống gỉ'
+    ]
+  },
+  {
+    id: 'lumen-knit-cardigan',
+    name: 'Lumen Knit Cardigan',
+    category: 'Áo cardigan',
+    price: '680.000đ',
+    description: 'Cardigan dệt kim mềm, cúc gỗ tự nhiên.',
+    longDescription:
+      'Lumen Knit Cardigan sở hữu chất len sợi tổng hợp mềm mại, giữ ấm vừa phải. Thiết kế cổ chữ V kinh điển kết hợp hàng cúc gỗ mang lại vẻ ngoài thanh lịch.',
+    image:
+      'https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=1200&q=80',
+    materials: '50% Viscose, 28% Nylon, 22% Polyester',
+    care: 'Giặt tay, không vắt mạnh, phơi ngang.',
+    colors: ['Kem Sữa', 'Nâu Hạt Dẻ'],
+    sizes: ['S', 'M', 'L'],
+    features: [
+      'Len mềm nhẹ thoải mái',
+      'Cúc gỗ tự nhiên',
+      'Túi ẩn hai bên'
+    ]
+  },
+  {
+    id: 'ripple-washed-jeans',
+    name: 'Ripple Washed Jeans',
+    category: 'Quần jeans',
+    price: '640.000đ',
+    description: 'Quần jeans slim fit wash loang nhẹ, co giãn thoải mái.',
+    longDescription:
+      'Ripple Washed Jeans sử dụng denim co giãn 2 chiều, xử lý wash loang và cào nhẹ tạo hiệu ứng vintage. Cạp quần trung bình dễ mặc, phù hợp với nhiều dáng người.',
+    image:
+      'https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=1200&q=80',
+    materials: '98% Cotton, 2% Elastane',
+    care: 'Giặt máy nước lạnh, lộn trái khi giặt.',
+    colors: ['Xanh Bạc'],
+    sizes: ['28', '30', '32', '34', '36'],
+    features: [
+      'Denim co giãn 2 chiều',
+      'Hiệu ứng wash vintage',
+      'Đường may chắc chắn'
+    ]
+  }
+];
+
+export default products;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -62,6 +62,10 @@ main {
   font-weight: 600;
   letter-spacing: 0.25em;
   text-transform: uppercase;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
 }
 
 .logo-icon {
@@ -86,15 +90,24 @@ main {
   letter-spacing: 0.08em;
 }
 
-.navigation a {
+.navigation a,
+.navigation .link-button {
   text-decoration: none;
   color: #111111;
   font-weight: 500;
   position: relative;
   padding-bottom: 0.25rem;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  cursor: pointer;
 }
 
-.navigation a::after {
+.navigation a::after,
+.navigation .link-button::after {
   content: '';
   position: absolute;
   left: 0;
@@ -105,8 +118,20 @@ main {
   transition: width 0.2s ease-in-out;
 }
 
-.navigation a:hover::after {
+.navigation a:hover::after,
+.navigation .link-button:hover::after,
+.navigation .link-button:focus-visible::after {
   width: 100%;
+}
+
+.navigation .link-button:focus-visible,
+.logo:focus-visible,
+.product-card:focus-visible,
+.product-detail__breadcrumb button:focus-visible,
+.product-detail__actions .secondary:focus-visible,
+.hero-actions button:focus-visible {
+  outline: 2px solid #111111;
+  outline-offset: 4px;
 }
 
 .search-area input {
@@ -116,6 +141,37 @@ main {
   width: 200px;
   background: rgba(255, 255, 255, 0.85);
   font-size: 0.85rem;
+}
+
+button.primary,
+button.secondary {
+  padding: 0.9rem 2.6rem;
+  border-radius: 999px;
+  border: none;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+button.primary {
+  background: #111111;
+  color: #ffffff;
+}
+
+button.primary:hover {
+  background: #2c2c2c;
+}
+
+button.secondary {
+  background: transparent;
+  color: #111111;
+  border: 1px solid #111111;
+}
+
+button.secondary:hover {
+  background: rgba(0, 0, 0, 0.08);
 }
 
 .hero {
@@ -161,34 +217,275 @@ main {
   gap: 1rem;
 }
 
-.hero-actions button {
-  padding: 0.9rem 2.6rem;
-  border-radius: 999px;
-  border: none;
+.product-section {
+  padding: 4rem 4rem 5rem;
+  background: #ffffff;
+}
+
+.section-header {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-subtitle {
+  letter-spacing: 0.35em;
   text-transform: uppercase;
-  letter-spacing: 0.15em;
-  font-weight: 600;
+  font-size: 0.85rem;
+  color: #9a9a9a;
+}
+
+.section-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-description {
+  font-size: 0.95rem;
+  color: #4a4a4a;
+  line-height: 1.7;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+}
+
+.product-card {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f9f9f9 0%, #ffffff 100%);
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 18px 36px -24px rgba(0, 0, 0, 0.2);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
   cursor: pointer;
-  transition: all 0.2s ease-in-out;
 }
 
-.hero-actions .primary {
-  background: #111111;
-  color: #ffffff;
+.product-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 48px -20px rgba(0, 0, 0, 0.25);
 }
 
-.hero-actions .primary:hover {
-  background: #2c2c2c;
+.product-card__image {
+  position: relative;
+  padding-top: 120%;
+  overflow: hidden;
 }
 
-.hero-actions .secondary {
+.product-card__image img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.product-card:hover .product-card__image img {
+  transform: scale(1.05);
+}
+
+.product-card__info {
+  padding: 1.75rem 1.75rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.product-card__category {
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: #9a9a9a;
+}
+
+.product-card__name {
+  font-size: 1.2rem;
+  letter-spacing: 0.05em;
+}
+
+.product-card__description {
+  font-size: 0.9rem;
+  color: #565656;
+  line-height: 1.6;
+  min-height: 3.5rem;
+}
+
+.product-card__price {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.product-detail {
+  padding: 4.5rem 4rem 5rem;
+  background: linear-gradient(180deg, #f7f7f7 0%, #ffffff 60%);
+}
+
+.product-detail__container {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.product-detail__breadcrumb {
+  margin-bottom: 2rem;
+}
+
+.product-detail__breadcrumb button {
+  background: none;
+  border: none;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  color: #111111;
+}
+
+.product-detail__layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+  align-items: start;
+}
+
+.product-detail__image {
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: 0 32px 56px -32px rgba(0, 0, 0, 0.35);
+}
+
+.product-detail__image img {
+  width: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.product-detail__info {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.product-detail__category {
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: #9a9a9a;
+}
+
+.product-detail__title {
+  font-size: clamp(2.3rem, 4vw, 3.2rem);
+  letter-spacing: 0.07em;
+  line-height: 1.2;
+}
+
+.product-detail__price {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.product-detail__description {
+  font-size: 1rem;
+  color: #3a3a3a;
+  line-height: 1.8;
+}
+
+.product-detail__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.product-detail__extra {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.product-detail__extra h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.85rem;
+  margin-bottom: 0.4rem;
+}
+
+.product-detail__extra p {
+  font-size: 0.95rem;
+  color: #444444;
+  line-height: 1.6;
+}
+
+.pill-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+}
+
+.pill-list li {
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  font-size: 0.85rem;
+}
+
+.product-detail__features h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.85rem;
+  margin-bottom: 0.75rem;
+}
+
+.product-detail__features ul {
+  list-style: disc;
+  margin-left: 1.2rem;
+  color: #3f3f3f;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.product-detail__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.product-detail__actions .primary,
+.product-detail__actions .secondary {
+  flex: 1 1 200px;
+}
+
+.product-detail__actions .secondary {
   background: transparent;
   color: #111111;
   border: 1px solid #111111;
 }
 
-.hero-actions .secondary:hover {
+.product-detail__actions .secondary:hover {
   background: rgba(0, 0, 0, 0.08);
+}
+
+.product-detail.not-found {
+  padding: 5rem 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.product-detail__content {
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .footer {
@@ -237,7 +534,9 @@ main {
 @media (max-width: 1024px) {
   .top-bar,
   .nav-bar,
-  .footer {
+  .footer,
+  .product-section,
+  .product-detail {
     padding-left: 2rem;
     padding-right: 2rem;
   }
@@ -249,6 +548,15 @@ main {
 
   .search-area input {
     width: 160px;
+  }
+
+  .product-detail__layout {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+  }
+
+  .product-detail__image {
+    max-height: 520px;
   }
 }
 
@@ -280,6 +588,48 @@ main {
 
   .hero-actions button {
     width: 100%;
+  }
+
+  .product-section {
+    padding: 3rem 1.5rem 4rem;
+  }
+
+  .section-header {
+    margin-bottom: 2.25rem;
+  }
+
+  .product-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .product-card__info {
+    padding: 1.5rem;
+  }
+
+  .product-card__description {
+    min-height: auto;
+  }
+
+  .product-detail {
+    padding: 3.5rem 1.5rem 4rem;
+  }
+
+  .product-detail__layout {
+    gap: 2rem;
+  }
+
+  .product-detail__actions {
+    flex-direction: column;
+  }
+
+  .product-detail__actions .primary,
+  .product-detail__actions .secondary {
+    width: 100%;
+  }
+
+  .product-detail__breadcrumb {
+    margin-bottom: 1.25rem;
   }
 
   .footer {


### PR DESCRIPTION
## Summary
- add a dedicated product catalogue with twenty curated items and accessible cards
- implement hash-based navigation to show product details alongside updated header and hero actions
- extend global and responsive styling for the product list and detail views

## Testing
- npm run build *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd104b0668832f9a0e2358f8b7d028